### PR TITLE
Extract EXIF metadata from files sent via Telegram bot

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -72,6 +72,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -979,6 +980,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1045,6 +1047,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -1226,6 +1229,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1358,6 +1362,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -1704,6 +1709,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2424,7 +2430,8 @@
     "node_modules/leaflet": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
-      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "peer": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -2776,6 +2783,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2787,6 +2795,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3108,6 +3117,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3160,6 +3170,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.14.tgz",
       "integrity": "sha512-+v57oAaoYNnO3hIu5Z/tJRZjq5aHM2zDve9YZ8HngVHbhk66RStobhb1sqPMIPEleV6cNKYK4eGrAbE9Ulbl2g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.4.0",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
+        "exifr": "^7.1.3",
         "express": "^4.18.2",
         "mime-types": "^3.0.2",
         "node-telegram-bot-api": "^0.63.0",
@@ -1715,6 +1716,12 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+    },
+    "node_modules/exifr": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
+      "integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw==",
+      "license": "MIT"
     },
     "node_modules/expand-template": {
       "version": "2.0.3",

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.4.0",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
+    "exifr": "^7.1.3",
     "express": "^4.18.2",
     "mime-types": "^3.0.2",
     "node-telegram-bot-api": "^0.63.0",

--- a/server/src/services/MetadataExtractor.ts
+++ b/server/src/services/MetadataExtractor.ts
@@ -1,0 +1,28 @@
+import exifr from 'exifr';
+
+export interface ExtractedMetadata {
+  latitude?: number;
+  longitude?: number;
+  capturedAt?: string;
+}
+
+export async function extractMetadata(filepath: string): Promise<ExtractedMetadata> {
+  try {
+    const data = await exifr.parse(filepath, {
+      gps: true,
+      pick: ['DateTimeOriginal', 'CreateDate'],
+    });
+
+    if (!data) return {};
+
+    const captureDate: Date | undefined = data.DateTimeOriginal ?? data.CreateDate;
+
+    return {
+      latitude: data.latitude,
+      longitude: data.longitude,
+      capturedAt: captureDate?.toISOString(),
+    };
+  } catch {
+    return {};
+  }
+}

--- a/server/src/services/TelegramBot.ts
+++ b/server/src/services/TelegramBot.ts
@@ -84,13 +84,23 @@ export class TelegramBotService {
         // Largest photo is last in the array
         const photo = msg.photo![msg.photo!.length - 1];
         const mediaPath = await this.downloadFile(photo.file_id, 'jpg');
+        // Photos sent with "Include metadata" keep their EXIF; pull capture
+        // time and GPS so the post reflects when/where it was taken rather
+        // than when it reached the bot.
+        const { latitude, longitude, capturedAt } = await extractMetadata(join(MEDIA_DIR, mediaPath));
         await this.savePost({
           type: 'photo',
           caption: msg.caption,
           media_path: mediaPath,
+          latitude,
+          longitude,
           telegram_user: username,
+          timestamp: capturedAt,
         });
-        await this.sendMessage(chatId, '✅ Foto sparat i flödet!');
+        const coordsMsg = latitude != null && longitude != null
+          ? ` Koordinater: ${latitude.toFixed(4)}, ${longitude.toFixed(4)}.`
+          : '';
+        await this.sendMessage(chatId, `✅ Foto sparat i flödet!${coordsMsg}`);
       } catch (error) {
         console.error('Error handling photo:', error);
         await this.sendMessage(chatId, '❌ Kunde inte spara fotot.');
@@ -103,13 +113,20 @@ export class TelegramBotService {
       const username = msg.from?.username || msg.from?.first_name || 'Unknown';
       try {
         const mediaPath = await this.downloadFile(msg.video!.file_id, 'mp4');
+        const { latitude, longitude, capturedAt } = await extractMetadata(join(MEDIA_DIR, mediaPath));
         await this.savePost({
           type: 'video',
           caption: msg.caption,
           media_path: mediaPath,
+          latitude,
+          longitude,
           telegram_user: username,
+          timestamp: capturedAt,
         });
-        await this.sendMessage(chatId, '✅ Video sparad i flödet!');
+        const coordsMsg = latitude != null && longitude != null
+          ? ` Koordinater: ${latitude.toFixed(4)}, ${longitude.toFixed(4)}.`
+          : '';
+        await this.sendMessage(chatId, `✅ Video sparad i flödet!${coordsMsg}`);
       } catch (error) {
         console.error('Error handling video:', error);
         await this.sendMessage(chatId, '❌ Kunde inte spara videon.');
@@ -162,40 +179,15 @@ export class TelegramBotService {
       const chatId = msg.chat.id;
       if (!isAllowed(msg)) { await this.sendMessage(chatId, '⛔ Not authorized.'); return; }
       const username = msg.from?.username || msg.from?.first_name || 'Unknown';
-      const { latitude, longitude } = msg.location!;
-
-      // Photo sent with "Include metadata": node-telegram-bot-api resolves the
-      // event type by the first matching key in its type list; 'location' (index 12)
-      // beats 'photo' (index 19), so these messages only fire the location event.
-      if (msg.photo) {
-        try {
-          const photo = msg.photo[msg.photo.length - 1];
-          const mediaPath = await this.downloadFile(photo.file_id, 'jpg');
-          await this.savePost({
-            type: 'photo',
-            caption: msg.caption,
-            media_path: mediaPath,
-            latitude,
-            longitude,
-            telegram_user: username,
-          });
-          await this.sendMessage(chatId, `✅ Foto sparat med koordinater! (${latitude.toFixed(4)}, ${longitude.toFixed(4)})`);
-        } catch (error) {
-          console.error('Error handling photo with metadata:', error);
-          await this.sendMessage(chatId, '❌ Kunde inte spara fotot.');
-        }
-        return;
-      }
-
       try {
         await this.savePost({
           type: 'text',
           caption: '📍 Platsuppdatering',
-          latitude,
-          longitude,
+          latitude: msg.location!.latitude,
+          longitude: msg.location!.longitude,
           telegram_user: username,
         });
-        await this.sendMessage(chatId, `✅ Plats sparad! (${latitude.toFixed(4)}, ${longitude.toFixed(4)})`);
+        await this.sendMessage(chatId, `✅ Plats sparad! (${msg.location!.latitude.toFixed(4)}, ${msg.location!.longitude.toFixed(4)})`);
       } catch (error) {
         console.error('Error handling location:', error);
         await this.sendMessage(chatId, '❌ Kunde inte spara platsen.');

--- a/server/src/services/TelegramBot.ts
+++ b/server/src/services/TelegramBot.ts
@@ -2,9 +2,11 @@ import axios from 'axios';
 import { createWriteStream, mkdirSync } from 'fs';
 import { join } from 'path';
 import TelegramBot from 'node-telegram-bot-api';
+import { lookup as mimeLookup } from 'mime-types';
 import { v4 as uuidv4 } from 'uuid';
 import { DatabaseManager } from '../models/database';
 import { Post } from '../types';
+import { extractMetadata } from './MetadataExtractor';
 
 export interface TelegramConfig {
   token: string;
@@ -114,6 +116,48 @@ export class TelegramBotService {
       }
     });
 
+    this.bot.on('document', async (msg) => {
+      const chatId = msg.chat.id;
+      if (!isAllowed(msg)) { await this.sendMessage(chatId, '⛔ Not authorized.'); return; }
+      const username = msg.from?.username || msg.from?.first_name || 'Unknown';
+      const doc = msg.document!;
+      const mimeType = doc.mime_type ?? '';
+
+      const isImage = mimeType.startsWith('image/');
+      const isVideo = mimeType.startsWith('video/');
+      if (!isImage && !isVideo) {
+        await this.sendMessage(chatId, '⚠️ Bara bilder och videor stöds.');
+        return;
+      }
+
+      const ext = (mimeLookup(mimeType) || mimeType.split('/')[1] || 'bin') as string;
+      const postType: Post['type'] = isImage ? 'photo' : 'video';
+
+      try {
+        const filename = await this.downloadFile(doc.file_id, ext);
+        const filepath = join(MEDIA_DIR, filename);
+        const { latitude, longitude, capturedAt } = await extractMetadata(filepath);
+
+        await this.savePost({
+          type: postType,
+          caption: msg.caption,
+          media_path: filename,
+          latitude,
+          longitude,
+          telegram_user: username,
+          timestamp: capturedAt,
+        });
+
+        const coordsMsg = latitude != null && longitude != null
+          ? ` Koordinater: ${latitude.toFixed(4)}, ${longitude.toFixed(4)}.`
+          : '';
+        await this.sendMessage(chatId, `✅ ${isImage ? 'Foto' : 'Video'} sparat i flödet!${coordsMsg}`);
+      } catch (error) {
+        console.error('Error handling document:', error);
+        await this.sendMessage(chatId, `❌ Kunde inte spara ${isImage ? 'fotot' : 'videon'}.`);
+      }
+    });
+
     this.bot.on('location', async (msg) => {
       const chatId = msg.chat.id;
       if (!isAllowed(msg)) { await this.sendMessage(chatId, '⛔ Not authorized.'); return; }
@@ -134,7 +178,7 @@ export class TelegramBotService {
     });
 
     this.bot.on('message', async (msg) => {
-      if (msg.photo || msg.video || msg.location) return;
+      if (msg.photo || msg.video || msg.location || msg.document) return;
 
       const chatId = msg.chat.id;
       if (!isAllowed(msg)) { await this.sendMessage(chatId, '⛔ Not authorized.'); return; }
@@ -181,9 +225,9 @@ export class TelegramBotService {
     return filename;
   }
 
-  private async savePost(data: Omit<Post, 'id' | 'timestamp'>): Promise<void> {
+  private async savePost(data: Omit<Post, 'id' | 'timestamp'> & { timestamp?: string }): Promise<void> {
     const id = uuidv4();
-    const timestamp = new Date().toISOString();
+    const timestamp = data.timestamp ?? new Date().toISOString();
 
     await this.db.run(
       `INSERT INTO posts (id, timestamp, type, caption, media_path, latitude, longitude, telegram_user)

--- a/server/src/services/TelegramBot.ts
+++ b/server/src/services/TelegramBot.ts
@@ -162,15 +162,40 @@ export class TelegramBotService {
       const chatId = msg.chat.id;
       if (!isAllowed(msg)) { await this.sendMessage(chatId, '⛔ Not authorized.'); return; }
       const username = msg.from?.username || msg.from?.first_name || 'Unknown';
+      const { latitude, longitude } = msg.location!;
+
+      // Photo sent with "Include metadata": node-telegram-bot-api resolves the
+      // event type by the first matching key in its type list; 'location' (index 12)
+      // beats 'photo' (index 19), so these messages only fire the location event.
+      if (msg.photo) {
+        try {
+          const photo = msg.photo[msg.photo.length - 1];
+          const mediaPath = await this.downloadFile(photo.file_id, 'jpg');
+          await this.savePost({
+            type: 'photo',
+            caption: msg.caption,
+            media_path: mediaPath,
+            latitude,
+            longitude,
+            telegram_user: username,
+          });
+          await this.sendMessage(chatId, `✅ Foto sparat med koordinater! (${latitude.toFixed(4)}, ${longitude.toFixed(4)})`);
+        } catch (error) {
+          console.error('Error handling photo with metadata:', error);
+          await this.sendMessage(chatId, '❌ Kunde inte spara fotot.');
+        }
+        return;
+      }
+
       try {
         await this.savePost({
           type: 'text',
           caption: '📍 Platsuppdatering',
-          latitude: msg.location!.latitude,
-          longitude: msg.location!.longitude,
+          latitude,
+          longitude,
           telegram_user: username,
         });
-        await this.sendMessage(chatId, `✅ Plats sparad! (${msg.location!.latitude.toFixed(4)}, ${msg.location!.longitude.toFixed(4)})`);
+        await this.sendMessage(chatId, `✅ Plats sparad! (${latitude.toFixed(4)}, ${longitude.toFixed(4)})`);
       } catch (error) {
         console.error('Error handling location:', error);
         await this.sendMessage(chatId, '❌ Kunde inte spara platsen.');


### PR DESCRIPTION
When a user sends an image or video as a file (document), the bot now
extracts GPS coordinates and capture timestamp from the file's EXIF/
metadata using exifr, and stores them in the posts table alongside the
media. Falls back gracefully when metadata is absent.

Closes #10

https://claude.ai/code/session_01SDpwaLxskJrBWuwiUGnjNG